### PR TITLE
Updates for PyVista 0.23.0 and stop building Python 2.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,7 @@ environment:
   CIBW_BEFORE_BUILD: "pip install numpy==1.15.0 cython"
   CIBW_TEST_REQUIRES: "pytest"
   CIBW_TEST_COMMAND: "pytest {project}\\tests\\"
-  CIBW_SKIP: "*win32* cp27-* cp33* cp34*"
+  CIBW_SKIP: "*win32* cp27-* cp33* cp34* cp38*"
   TWINE_USERNAME: akaszynski
   # Note: TWINE_PASSWORD is set in Appveyor settings
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - CIBW_BEFORE_BUILD_MACOS="pip install numpy==1.15.0; pip install cython"
     - CIBW_TEST_REQUIRES="pytest"
     - CIBW_TEST_COMMAND="pytest {project}/tests/"
-    - CIBW_SKIP="cp27-cp27m-manylinux1_x86_64 cp34-* *manylinux1_i686*"
+    - CIBW_SKIP="cp27-* cp34-* *manylinux1_i686*"
     - TWINE_USERNAME=akaszynski
       # Note: TWINE_PASSWORD is set in Travis settings
     # Doctr deploy key for pyvista/pymeshfix

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - CIBW_BEFORE_BUILD_MACOS="pip install numpy==1.15.0; pip install cython"
     - CIBW_TEST_REQUIRES="pytest"
     - CIBW_TEST_COMMAND="pytest {project}/tests/"
-    - CIBW_SKIP="cp27-* cp34-* *manylinux1_i686*"
+    - CIBW_SKIP="cp27-* cp34-* cp38-* *manylinux1_i686*"
     - TWINE_USERNAME=akaszynski
       # Note: TWINE_PASSWORD is set in Travis settings
     # Doctr deploy key for pyvista/pymeshfix

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@
 # https://github.com/python-rapidjson/python-rapidjson/blob/master/.appveyor.yml
 
 # Builds wheels for Linux using cibuildwheel, inside the manylinux1 Docker image.
-# builds 64-bit Python2.7, Python3.5, Python3.6, Python3.7
+# builds 64-bit Python3.5, Python3.6, Python3.7
 
 dist: xenial
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - |
     if [ "$TRAVIS_OS_NAME" != "osx" ]; then
       cd ./wheelhouse
-      pip3 install pymeshfix-*-cp37-cp37m-manylinux1_x86_64.whl
+      pip3 install pymeshfix-*-cp37-cp37m-*.whl
       cd ../docs
       make html
       set -e

--- a/examples/cow.py
+++ b/examples/cow.py
@@ -16,7 +16,7 @@ cow = examples.download_cow()
 
 # Add holes and cast to triangulated PolyData
 cow['random'] = np.random.rand(cow.n_cells)
-holy_cow = cow.threshold(0.9, invert=True).extract_geometry().tri_filter()
+holy_cow = cow.threshold(0.9, invert=True).extract_geometry().triangulate()
 print(holy_cow)
 
 ################################################################################

--- a/examples/torso.py
+++ b/examples/torso.py
@@ -25,7 +25,7 @@ mesh.plot(color=True, show_edges=True, cpos=cpos)
 
 ################################################################################
 # Appy a triangle filter to ensure the mesh is simply polyhedral
-meshfix = mf.MeshFix(mesh.tri_filter())
+meshfix = mf.MeshFix(mesh.triangulate())
 holes = meshfix.extract_holes()
 
 ################################################################################

--- a/pymeshfix/meshfix.py
+++ b/pymeshfix/meshfix.py
@@ -27,8 +27,8 @@ class MeshFix(object):
 
             # check if triangular mesh
             faces = mesh.faces
-            if faces.size % 4:
-                tri_mesh = mesh.tri_filter()
+            if not mesh.is_all_triangles():
+                tri_mesh = mesh.triangulate()
                 faces = tri_mesh.faces
 
             self.f = np.ascontiguousarray(faces.reshape(-1 , 4)[:, 1:])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyvista>=0.22.4
+pyvista>=0.23.0
 Sphinx<=2.0.0
 sphinx-autobuild>
 sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
     keywords='meshfix',
     package_data={'pymeshfix/examples': ['StanfordBunny.ply']},
     install_requires=['numpy>1.11.0',
-                      'pyvista>=0.20.2']
+                      'pyvista>=0.23.0']
 )
 
 # revert to prior directory

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,6 @@ setup(
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Science/Research',
                  'License :: OSI Approved :: MIT License',
-                 'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3.5',
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7'],


### PR DESCRIPTION
Resolve #12 and a few general updates for PyVista v0.23.0

Also stops building wheels for Python 2.7. No builds for Python 3.8 as VTK does not have wheels for 3.8 yet