### PR TITLE
Fix repair_planar example by specifying dtype=np.int32

### DIFF
--- a/examples/repair_planar.py
+++ b/examples/repair_planar.py
@@ -42,7 +42,7 @@ mfix.fill_small_boundaries(nbe=100, refine=True)
 ###############################################################################
 # Convert back to a pyvista mesh
 vert, faces = mfix.return_arrays()
-triangles = np.empty((faces.shape[0], 4))
+triangles = np.empty((faces.shape[0], 4), dtype=faces.dtype)
 triangles[:, -3:] = faces
 triangles[:, 0] = 3
 


### PR DESCRIPTION
Fixes: "TypeError: Indices must be either a mask or an integer array-like". By
inspecting the triangles array, I realized that it had dtype=np.float64.