### PR TITLE
MAINT: Fixes for NumPy deprecation and 3.10

### DIFF
--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -2,12 +2,8 @@
 
 steps:
 - script: |
-    python -m pip install --find-links https://wheels.pyvista.org/ pyvista
-  displayName: 'Work around Python 3.10 VTK wheels missing'
-
-- script: |
-    python -m pip wheel . -w wheelhouse/
-  displayName: 'Build wheel'
+    python -m pip wheel . -w wheelhouse/ --find-links https://wheels.pyvista.org/
+  displayName: 'Build wheel with 3.10 VTK workaround'
 
 - script: |
     python -m pip install $(package_name) --no-index -f wheelhouse/ --upgrade --ignore-installed

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -2,7 +2,7 @@
 
 steps:
 - script: |
-    python -m pip wheel . -w wheelhouse/ --find-links https://wheels.pyvista.org/
+    python -m pip wheel . -w wheelhouse/ --find-links https://wheels.pyvista.org/ --only-binary="numpy"
   displayName: 'Build wheel with 3.10 VTK workaround'
 
 - script: |

--- a/.ci/azure-steps.yml
+++ b/.ci/azure-steps.yml
@@ -2,6 +2,10 @@
 
 steps:
 - script: |
+    python -m pip install --find-links https://wheels.pyvista.org/ pyvista
+  displayName: 'Work around Python 3.10 VTK wheels missing'
+
+- script: |
     python -m pip wheel . -w wheelhouse/
   displayName: 'Build wheel'
 

--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -26,4 +26,4 @@ cd io
 "${PYBIN}/python" setup.py bdist_wheel
 auditwheel repair dist/$package_name*.whl
 rm -f dist/*
-mv wheelhouse/*manylinux_2_24* dist/
+mv wheelhouse/*manylinux2014* dist/

--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -26,4 +26,4 @@ cd io
 "${PYBIN}/python" setup.py bdist_wheel
 auditwheel repair dist/$package_name*.whl
 rm -f dist/*
-mv wheelhouse/*manylinux2010* dist/
+mv wheelhouse/*manylinux_2_24* dist/

--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -6,9 +6,6 @@ set -e -x
 # build based on python version from args
 PYTHON_VERSION="$1"
 case $PYTHON_VERSION in
-3.6)
-  PYBIN="/opt/python/cp36-cp36m/bin"
-  ;;
 3.7)
   PYBIN="/opt/python/cp37-cp37m/bin"
   ;;
@@ -17,6 +14,9 @@ case $PYTHON_VERSION in
   ;;
 3.9)
   PYBIN="/opt/python/cp39-cp39/bin"
+  ;;
+3.10)
+  PYBIN="/opt/python/cp310-cp310/bin"
   ;;
 esac
 

--- a/.ci/macos-install-python.sh
+++ b/.ci/macos-install-python.sh
@@ -3,17 +3,17 @@
 PYTHON_VERSION="$1"
 
 case $PYTHON_VERSION in
-2.7)
-  FULL_VERSION=2.7.16
-  ;;
-3.6)
-  FULL_VERSION=3.6.8
-  ;;
 3.7)
   FULL_VERSION=3.7.7
   ;;
 3.8)
   FULL_VERSION=3.8.3
+  ;;
+3.9)
+  FULL_VERSION=3.9.12
+  ;;
+3.10)
+  FULL_VERSION=3.10.4
   ;;
 esac
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -29,10 +29,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Build package
+      - name: Setup dependencies
         run: |
           pip install -r requirements_build.txt --only-binary="numpy" --find-links https://wheels.pyvista.org/
+
+      - name: Build wheel
+        run: |
           python setup.py bdist_wheel
+
+      - name: Install wheel
+        run: |
           pip install dist/* --find-links https://wheels.pyvista.org/
 
       - name: Install package

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build package
         run: |
-          pip install -r requirements_build.txt
+          pip install -r requirements_build.txt --only-binary="numpy"
           python setup.py bdist_wheel
           pip install dist/*
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -37,9 +37,13 @@ jobs:
         run: |
           python setup.py bdist_wheel
 
+      - name: Install vtk
+        run: |
+          pip install --find-links https://wheels.pyvista.org/ vtk
+
       - name: Install wheel
         run: |
-          pip install dist/* --find-links https://wheels.pyvista.org/
+          pip install dist/*
 
       - name: Install package
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -12,12 +12,18 @@ on:
 
 jobs:
   macOS:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     name: Mac OS Unit Testing
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-
+        os: ['macos-latest']
+        exclude:
+          - os: macos-latest
+            python-version: '3.10'
+        include:
+          - os: macos-12
+            python-version: '3.10'
     env:
       SHELLOPTS: 'errexit:pipefail'
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Upgrade pip on 3.10 so that wheels can be found
         run: |
           pip install --upgrade pip
+          pip debug --verbose
+          pip debug --verbose | grep 310-macosx_12_0
         if: ${{ matrix.os == 'macos-12' }}
 
       - name: Install vtk

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -47,7 +47,8 @@ jobs:
       - name: Manually install VTK wheel on 3.10 since it does not work locally
         run: |
           pip install --upgrade pip
-          pip install https://wheels.pyvista.org/vtk-9.1.0.dev0-cp310-cp310-macosx_12_0_x86_64.whl
+          curl https://wheels.pyvista.org/vtk-9.1.0.dev0-cp310-cp310-macosx_12_0_x86_64.whl -o vtk-9.1.0.dev0-cp310-cp310-macosx_10_16_x86_64.whl
+          pip install ./vtk-9.1.0.dev0-cp310-cp310-macosx_10_16_x86_64.whl
         if: ${{ matrix.os == 'macos-12' }}
 
       - name: Install vtk

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upgrade pip on 3.10 so that wheels can be found
         run: |
           pip install --upgrade pip
-        if: ${{ matrix.python_version == '3.10' }}
+        if: ${{ matrix.os == 'macos-12' }}
 
       - name: Install vtk
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -16,11 +16,8 @@ jobs:
     name: Mac OS Unit Testing
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
         os: ['macos-11']
-        exclude:
-          - python-version: '3.10'
-            os: macos-11
         include:
           - python-version: '3.10'
             os: macos-12

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upgrade pip on 3.10 so that wheels can be found
       # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#manylinux-compatibility-support
         run: |
-          pip install --upgrade "pip>=19.3" "auditwheel>=3.0.0"
+          pip install --upgrade "pip>=19.3" "auditwheel>=3.0.0" wheel
           pip debug --verbose
           pip debug --verbose | grep 310-macosx_12_0
         if: ${{ matrix.os == 'macos-12' }}

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build package
         run: |
           pip install -r requirements_build.txt --only-binary="numpy" --find-links https://wheels.pyvista.org/
-          python setup.py bdist_wheel --find-links https://wheels.pyvista.org/
+          python setup.py bdist_wheel
           pip install dist/* --find-links https://wheels.pyvista.org/
 
       - name: Install package

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -19,11 +19,12 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         os: ['macos-11']
         exclude:
-          - os: macos-11
-            python-version: '3.10'
+          - python-version: '3.10'
+            os: macos-11
         include:
-          - os: macos-12
-            python-version: '3.10'
+          - python-version: '3.10'
+            os: macos-12
+
     env:
       SHELLOPTS: 'errexit:pipefail'
 
@@ -42,6 +43,11 @@ jobs:
       - name: Build wheel
         run: |
           python setup.py bdist_wheel
+
+      - name: Upgrade pip on 3.10 so that wheels can be found
+        run: |
+          pip install --upgrade pip
+        if: ${{ matrix.python_version == '3.10' }}
 
       - name: Install vtk
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build package
         run: |
-          pip install -r requirements_build.txt --only-binary="numpy"
+          pip install -r requirements_build.txt --only-binary="numpy" --find-links https://wheels.pyvista.org/
           python setup.py bdist_wheel
           pip install dist/*
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -44,12 +44,10 @@ jobs:
         run: |
           python setup.py bdist_wheel
 
-      - name: Upgrade pip on 3.10 so that wheels can be found
-      # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#manylinux-compatibility-support
+      - name: Manually install VTK wheel on 3.10 since it does not work locally
         run: |
-          pip install --upgrade "pip>=19.3" "auditwheel>=3.0.0" wheel
-          pip debug --verbose
-          pip debug --verbose | grep 310-macosx_12_0
+          pip install --upgrade pip
+          pip install https://wheels.pyvista.org/vtk-9.1.0.dev0-cp310-cp310-macosx_12_0_x86_64.whl
         if: ${{ matrix.os == 'macos-12' }}
 
       - name: Install vtk

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -45,8 +45,9 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Upgrade pip on 3.10 so that wheels can be found
+      # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#manylinux-compatibility-support
         run: |
-          pip install --upgrade pip
+          pip install --upgrade "pip>=19.3" "auditwheel>=3.0.0"
           pip debug --verbose
           pip debug --verbose | grep 310-macosx_12_0
         if: ${{ matrix.os == 'macos-12' }}

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -45,9 +45,8 @@ jobs:
         run: |
           pip install dist/*
 
-      - name: Install package
+      - name: Check package
         run: |
-          pip install dist/*
           python -c "import pyvista; print(pyvista.Report(gpu=False))"
 
       - name: Install test dependencies

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build package
         run: |
           pip install -r requirements_build.txt --only-binary="numpy" --find-links https://wheels.pyvista.org/
-          python setup.py bdist_wheel
+          python setup.py bdist_wheel --find-links https://wheels.pyvista.org/
           pip install dist/* --find-links https://wheels.pyvista.org/
 
       - name: Install package

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pip install -r requirements_build.txt --only-binary="numpy" --find-links https://wheels.pyvista.org/
           python setup.py bdist_wheel
-          pip install dist/*
+          pip install dist/* --find-links https://wheels.pyvista.org/
 
       - name: Install package
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        os: ['macos-latest']
+        os: ['macos-11']
         exclude:
-          - os: macos-latest
+          - os: macos-11
             python-version: '3.10'
         include:
           - os: macos-12
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install vtk
         run: |
-          pip install --find-links https://wheels.pyvista.org/ vtk
+          pip install --find-links https://wheels.pyvista.org/ vtk -vvv
 
       - name: Install wheel
         run: |

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -1,4 +1,7 @@
 name: Unit Testing
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -13,7 +16,7 @@ jobs:
     name: Mac OS Unit Testing
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     env:
       SHELLOPTS: 'errexit:pipefail'

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ within memory and wish to repair it using MeshFix.
     mesh = meshfix.mesh
 
     # Or, access the resulting arrays directly from the object
-    meshfix.v # numpy np.float array
+    meshfix.v # numpy np.float64 array
     meshfix.f # numpy np.int32 array
 
     # View the repaired mesh (requires vtkInterface)
@@ -148,13 +148,13 @@ algorithm.
 
     # Fill holes
     tin.fill_small_boundaries()
-    print('There are {:d} boundaries'.format(tin.boundaries())
+    print('There are {:d} boundaries'.format(tin.boundaries()))
 
     # Clean (removes self intersections)
     tin.clean(max_iters=10, inner_loops=3)
 
     # Check mesh for holes again
-    print('There are {:d} boundaries'.format(tin.boundaries())
+    print('There are {:d} boundaries'.format(tin.boundaries()))
 
     # Clean again if necessary...
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ jobs:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
-      Python39:
+      Python310:
         python.version: '3.10'
   steps:
     - template: .ci/azure-setup.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,14 +15,14 @@ jobs:
 - job: Linux
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python39:
+        python.version: '3.10'
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
@@ -52,14 +52,14 @@ jobs:
     python.architecture: 'x64'
   strategy:
     matrix:
-      Python36:
-        python.version: '3.6'
       Python37:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python39:
+        python.version: '3.10'
   steps:
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
         docker run -e package_name=$(package_name) --rm -v `pwd`:/io quay.io/pypa/manylinux2014_x86_64 /io/.ci/build_wheels.sh $(python.version)
       displayName: Build wheel using manylinux2014
     - script: |
-        pip install dist/*.whl
+        pip install dist/*.whl --find-links https://wheels.pyvista.org/
       displayName: Install wheel
     - script: |
         pip install -r requirements_test.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
-      Python39:
+      Python310:
         python.version: '3.10'
   pool:
     vmImage: 'ubuntu-18.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,9 @@ jobs:
       displayName: 'Use Python $(python.version)'
     - script: |
         set -ex
-        docker pull quay.io/pypa/manylinux2010_x86_64
-        docker run -e package_name=$(package_name) --rm -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/.ci/build_wheels.sh $(python.version)
-      displayName: Build wheel using manylinux2010
+        docker pull quay.io/pypa/manylinux_2_24_x86_64
+        docker run -e package_name=$(package_name) --rm -v `pwd`:/io quay.io/pypa/manylinux_2_24_x86_64 /io/.ci/build_wheels.sh $(python.version)
+      displayName: Build wheel using manylinux_2_24
     - script: |
         pip install dist/*.whl
       displayName: Install wheel

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,9 @@ jobs:
       displayName: 'Use Python $(python.version)'
     - script: |
         set -ex
-        docker pull quay.io/pypa/manylinux_2_24_x86_64
-        docker run -e package_name=$(package_name) --rm -v `pwd`:/io quay.io/pypa/manylinux_2_24_x86_64 /io/.ci/build_wheels.sh $(python.version)
-      displayName: Build wheel using manylinux_2_24
+        docker pull quay.io/pypa/manylinux2014_x86_64
+        docker run -e package_name=$(package_name) --rm -v `pwd`:/io quay.io/pypa/manylinux2014_x86_64 /io/.ci/build_wheels.sh $(python.version)
+      displayName: Build wheel using manylinux2014
     - script: |
         pip install dist/*.whl
       displayName: Install wheel

--- a/pymeshfix/_version.py
+++ b/pymeshfix/_version.py
@@ -6,5 +6,5 @@ For example:
 version_info = 0, 27, 'dev0'
 
 """
-version_info = 0, 15, 'dev0'
+version_info = 0, 16, 'dev0'
 __version__ = '.'.join(map(str, version_info))

--- a/pymeshfix/cython/_meshfix.pyx
+++ b/pymeshfix/cython/_meshfix.pyx
@@ -128,7 +128,7 @@ cdef class PyTMesh:
 
         """
         if self.n_points:
-            raise Exception('Cannot load a new file once initialized')
+            raise RuntimeError('Cannot load a new file once initialized')
 
         # Initializes triangulation
         py_byte_string = filename.encode('UTF-8')
@@ -194,26 +194,15 @@ cdef class PyTMesh:
 
         """
         if self.n_points:
-            raise Exception('Cannot load new arrays once initialized')
+            raise RuntimeError('Cannot load new arrays once initialized')
 
-        if not v.flags['C_CONTIGUOUS']:
-            if v.dtype not in (float, np.float64):
-                v = np.ascontiguousarray(v, dtype=np.float64)
-            else:
-                v = np.ascontiguousarray(v)
-        elif v.dtype not in (float, np.float64):
-            v = v.astype(np.float64)
+        v = np.ascontiguousarray(v, dtype=np.float64)
 
         # Ensure inputs are of the right type
-        assert f.ndim == 2, 'Face array must be 2D numpy array'
-        assert f.shape[1] == 3, 'Face array must contain three columns'
-        if not f.flags['C_CONTIGUOUS']:
-            if f.dtype != ctypes.c_int:
-                f = np.ascontiguousarray(f, dtype=ctypes.c_int)
-            else:
-                f = np.ascontiguousarray(f)
-        elif f.dtype != ctypes.c_int:
-            f = f.astype(ctypes.c_int)
+        f = np.ascontiguousarray(f, dtype=ctypes.c_int)
+        if f.ndim != 2 or f.shape[1] != 3:
+            raise ValueError(
+                f'Face array must be 2D with three columns, got {f.shape}')
 
         cdef int nv = v.shape[0]
         cdef double [::1] points = v.ravel()

--- a/pymeshfix/cython/_meshfix.pyx
+++ b/pymeshfix/cython/_meshfix.pyx
@@ -197,12 +197,12 @@ cdef class PyTMesh:
             raise Exception('Cannot load new arrays once initialized')
 
         if not v.flags['C_CONTIGUOUS']:
-            if v.dtype != np.float:
-                v = np.ascontiguousarray(v, dtype=np.float)
+            if v.dtype not in (float, np.float64):
+                v = np.ascontiguousarray(v, dtype=np.float64)
             else:
                 v = np.ascontiguousarray(v)
-        elif v.dtype != np.float:
-            v = v.astype(np.float)
+        elif v.dtype not in (float, np.float64):
+            v = v.astype(np.float64)
 
         # Ensure inputs are of the right type
         assert f.ndim == 2, 'Face array must be 2D numpy array'

--- a/pymeshfix/meshfix.py
+++ b/pymeshfix/meshfix.py
@@ -76,7 +76,7 @@ class MeshFix(object):
         # Check inputs
         if not isinstance(v, np.ndarray):
             try:
-                v = np.asarray(v, np.float)
+                v = np.asarray(v, np.float64)
                 if v.ndim != 2 and v.shape[1] != 3:
                     raise Exception('Invalid vertex format.  Shape ' +
                                     'should be (npoints, 3)')

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,5 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy<=1.21.3
+numpy<1.20.0; python_version<3.10
+numpy<=1.21.3; python_version>=3.10
 cython>=0.29.0

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,5 +1,5 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy<1.20.0; python_version < 3.10
-numpy<=1.21.3; python_version >= 3.10
+numpy<1.20.0; python_version < '3.10'
+numpy<=1.21.3; python_version >= '3.10'
 cython>=0.29.0

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy<1.20.0
+numpy<1.21.0
 cython>=0.29.0

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,5 +1,5 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy<1.20.0; python_version < '3.10'
+numpy<1.20.0; python_version >= '3.7' and python_version <= '3.9'
 numpy<=1.21.3; python_version >= '3.10'
 cython>=0.29.0

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,4 +1,4 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy<1.21.0
+numpy<=1.21.3
 cython>=0.29.0

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,5 +1,5 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy<1.20.0; python_version<3.10
-numpy<=1.21.3; python_version>=3.10
+numpy<1.20.0; python_version < 3.10
+numpy<=1.21.3; python_version >= 3.10
 cython>=0.29.0

--- a/setup.py
+++ b/setup.py
@@ -102,11 +102,11 @@ setup(
     classifiers=['Development Status :: 4 - Beta',
                  'Intended Audience :: Science/Research',
                  'License :: OSI Approved :: MIT License',
-                 'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
     ],
+    python_requires='>=3.7',
     url='https://github.com/pyvista/pymeshfix',
 
     # Build cython modules

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
                  'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.10',
     ],
     python_requires='>=3.7',
     url='https://github.com/pyvista/pymeshfix',


### PR DESCRIPTION
1. `np.float` is just an alias for `float` so avoid the deprecation warning about it.
2. Change to `manylinux2014` for Python3.10 support
3. Add shims for VTK not having a 3.10 wheel (via `wheels.pyvistia.org`)

FYI it would be good to merge this and cut a release since there are no Python 3.10 wheels for `pymeshfix`.