### PR TITLE
FIX: Comment out print

### DIFF
--- a/pymeshfix/_version.py
+++ b/pymeshfix/_version.py
@@ -6,5 +6,5 @@ For example:
 version_info = 0, 27, 'dev0'
 
 """
-version_info = 0, 17, 'dev0'
+version_info = 0, 16, 1
 __version__ = '.'.join(map(str, version_info))

--- a/pymeshfix/cython/_meshfix.pyx
+++ b/pymeshfix/cython/_meshfix.pyx
@@ -103,12 +103,13 @@ cdef class PyTMesh:
 
     cdef Basic_TMesh_wrap c_tmesh  # hold a C++ instance which we're wrapping
 
-    def __cinit__(self, quiet=1):
+    def __cinit__(self, verbose=1):
         """ Create TMesh object """
         self.c_tmesh = Basic_TMesh_wrap()
 
         # Enable/Disable printed progress
-        self.c_tmesh.SetVerbose(not quiet)
+        quiet = 0 if verbose else 1
+        self.c_tmesh.SetVerbose(quiet)
 
     def load_file(self, filename):
         """

--- a/pymeshfix/cython/holeFilling.cpp
+++ b/pymeshfix/cython/holeFilling.cpp
@@ -600,7 +600,7 @@ int Basic_TMesh::refineSelectedHolePatches(Triangle *t0)
  }
  else FOREACHTRIANGLE(t, n) if (IS_VISITED(t)) reg.appendHead(t);
 
- printf("%d\n",reg.numels());
+ // printf("%d\n",reg.numels());
 
  FOREACHVTTRIANGLE((&reg), t, n)
  {

--- a/tests/test_pyx_meshfix.py
+++ b/tests/test_pyx_meshfix.py
@@ -67,7 +67,7 @@ def test_remove_components():
 
 
 def test_select_intersecting_triangles():
-    meshfix = _meshfix.PyTMesh(quiet=0)
+    meshfix = _meshfix.PyTMesh(verbose=0)
     meshfix.load_file(examples.bunny_scan)
     faces = meshfix.select_intersecting_triangles()
     assert faces.any()


### PR DESCRIPTION
1. Comment out `printf` that really shouldn't be there -- this seems like debug cruft that should go in a `TMesh::debug`, but this does not seem to exist. Adding it as `TMesh::info` messes up the printing, so probably best just to comment it out.
2. Change the `__cinit__` from `quiet=1` to `verbose=1`. `quiet` here was really being used like `verbose` in Python land, so let's make the `__cinit__` be where the inversion clearly happens.

## verbose=True

Before these changes, this is the sort of output I was getting with `verbose=True`:
```
INFO- Loaded 40962 vertices and 81920 faces.
Fixing degeneracies and intersections
INFO- ********* ITERATION 0 *********
INFO- Removing degeneracies...
INFO- Removing self-intersections...

98 % done   
INFO- No intersections detected.
INFO- Loaded 40962 vertices and 30000 faces.
WARNING- 12594 isolated vertices have been removed.
Patching holes...

0% done 323
0% done 50
0% done 50
0% done 31
1% done 69
1% done 69
1% done 69
1% done 50
2% done 69
2% done 169
2% done 50
...
```
You can see the `printf` with a `\n` messed up the formatting of what is otherwise a nice inline update:
```
INFO- Loaded 40962 vertices and 81920 faces.
Fixing degeneracies and intersections
INFO- ********* ITERATION 0 *********
INFO- Removing degeneracies...
INFO- Removing self-intersections...

98 % done   
INFO- No intersections detected.
INFO- Loaded 40962 vertices and 30000 faces.
WARNING- 12594 isolated vertices have been removed.
Patching holes...

100% done 
Patched 387 holes
```

## verbose=False
And it fixes the bug that I was really having, namely that doing `verbose=False` wasn't suppressing all output as I would still see a bunch of lines with just integers printed on master:
```
323
50
50
31
69
69
69
50
69
169
50
...
```
These are gone on this PR and the output is properly silenced.

In principle this should maybe be backported, but the repo does not look very active: https://github.com/MarcoAttene/MeshFix-V2.1/pulls?q=is%3Apr+is%3Aclosed

If it's okay @akaszynski I'd like to merge this, bump to 0.16.1, and release again. Okay with you?