### PR TITLE
Align setup.py classifiers with the project's GPL license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ setup(
     long_description_content_type="text/x-rst",
     author="PyVista Developers",
     author_email="info@pyvista.org",
-    license="MIT",
+    license="GPLv3",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
This is to ensure that pypi does not contain misleading information about the license, especially since it is a copyleft one.