### PR TITLE
MAINT: Bump to 3.9 and NumPy 2

### DIFF
--- a/pymeshfix/_version.py
+++ b/pymeshfix/_version.py
@@ -7,5 +7,5 @@ version_info = 0, 27, 'dev0'
 
 """
 
-version_info = 0, 18, dev0
+version_info = 0, 18, "dev0"
 __version__ = ".".join(map(str, version_info))

--- a/pymeshfix/_version.py
+++ b/pymeshfix/_version.py
@@ -7,5 +7,5 @@ version_info = 0, 27, 'dev0'
 
 """
 
-version_info = 0, 17, "dev0"
+version_info = 0, 17, 0
 __version__ = ".".join(map(str, version_info))

--- a/pymeshfix/_version.py
+++ b/pymeshfix/_version.py
@@ -7,5 +7,5 @@ version_info = 0, 27, 'dev0'
 
 """
 
-version_info = 0, 17, 0
+version_info = 0, 18, dev0
 __version__ = ".".join(map(str, version_info))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=42",
     "wheel>=0.33.0",
     "cython>=3.0.0",
-    "oldest-supported-numpy"
+    "numpy>=2,<3",
 ]
 
 build-backend = "setuptools.build_meta"
@@ -18,7 +18,7 @@ filterwarnings = [
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-skip = "pp* *musllinux* cp37-*"  # disable PyPy and musl-based wheels and Python<3.8
+skip = "pp* *musllinux* cp37-* cp38-*"  # disable PyPy and musl-based wheels and Python<3.9
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 

--- a/setup.py
+++ b/setup.py
@@ -53,13 +53,12 @@ setup(
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     url="https://github.com/pyvista/pymeshfix",
     # Build cython modules
     ext_modules=cythonize(


### PR DESCRIPTION
1. Make 3.9 the min Python. Should be safe enough nowadays since NumPy 2.0 didn't release 3.8 wheels.
2. Build against NumPy 2.0
3. Set version in prep for release

@akaszynski I suggest we merge this PR then cut a 0.17.0 release

Closes #65