### PR TITLE
AARCH64 builds

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Waiting for VTK arm builds from my PR: https://gitlab.kitware.com/vtk/vtk/-/issues/19605

FYI:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Digits, jetson thor, cuda arm laptops are coming

windows arm q2 2025: https://github.com/github/roadmap/issues/1098

ubuntu 20.04 is deprecated from today