### PR TITLE
Fix outdated repair() doc

### DIFF
--- a/src/pymeshfix/meshfix.py
+++ b/src/pymeshfix/meshfix.py
@@ -395,8 +395,6 @@ class MeshFix:
 
         Parameters
         ----------
-        fill_holes : bool, default: True
-            Call meshfix's internal ``fill_small_boundaries``.
         joincomp : bool, default: False
             Attempts to join nearby open components.
         remove_smallest_components : bool, default: True


### PR DESCRIPTION
Currently the documentation for `repair()`  at https://pymeshfix.pyvista.org/_autosummary/_autosummary/pymeshfix.MeshFix.repair.html#pymeshfix-meshfix-repair mentions the `fill_holes` parameter, which does not seem to exist. 

This PR simply removes that line from the doc.